### PR TITLE
[FIX] l10n_it_declaration_of_intent: fix warnings raised during tests…

### DIFF
--- a/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
+++ b/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
@@ -39,7 +39,6 @@ class TestDeclarationOfIntent(AccountTestInvoicingCommon):
         )
         invoice_form.partner_id = partner
         invoice_form.invoice_date = date if date else cls.today_date
-        invoice_form.name = "Test invoice " + name
         invoice_form.invoice_payment_term_id = cls.env.ref(
             "account.account_payment_term_advance"
         )


### PR DESCRIPTION
… execution such as following:

2022-02-08 08:10:43,744 111657 WARNING 14.0-test-pr2640 odoo.tests.common.onchange: The sequence format has changed. It was previously 'Test invoice 3' and it is now 'Test invoice no valid taxes'.

The sequence will never restart.
The incrementing number in this case is '0'.
2022-02-08 08:10:44,608 111657 WARNING 14.0-test-pr2640 odoo.tests.common.onchange: The sequence format has changed. It was previously 'Test invoice no valid taxes' and it is now 'Test invoice future'.

See https://github.com/OCA/l10n-italy/runs/5100117472?check_suite_focus=true#step:8:334 for further info

Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
